### PR TITLE
edit app label

### DIFF
--- a/packages/DocumentsUI/res/values-de/strings.xml
+++ b/packages/DocumentsUI/res/values-de/strings.xml
@@ -16,7 +16,7 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_label" msgid="1551050262492398204">"Dateien"</string>
+    <string name="app_label" msgid="1551050262492398204">"Dokumente"</string>
     <string name="downloads_label" msgid="959113951084633612">"Downloads"</string>
     <string name="title_open" msgid="4353228937663917801">"Öffnen von"</string>
     <string name="title_save" msgid="2433679664882857999">"Speichern unter"</string>


### PR DESCRIPTION
DocumentsUI -> Dokuments
And for all languages.

In German Dokumente and in English Documents.

Now is in English files and Dokumente.

![photo_2017-06-21_21-55-15](https://user-images.githubusercontent.com/6131799/27403871-68e873fc-56cc-11e7-9982-51c0efaf7420.jpg)
![photo_2017-06-21_21-55-21](https://user-images.githubusercontent.com/6131799/27403874-6b08e982-56cc-11e7-97a3-f99bc624959b.jpg)
