### PR TITLE
Fw/base: Enable home button wake

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -4632,7 +4632,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         }
 
         // Disable hw keys in Ambient and when screen off
-        if ((isDozeMode() || !isScreenOn()) && (appSwitchKey || homeKey || menuKey || backKey)) {
+        if ((isDozeMode() || !isScreenOn()) && (appSwitchKey || menuKey || backKey)) {
             return 0;
         }
 


### PR DESCRIPTION
Don't disable home button key when in ambient and when screen is off so that we can use it as a wake key