### PR TITLE
Allow Seamless rotation while PIP is active

### DIFF
--- a/services/core/java/com/android/server/wm/DisplayContent.java
+++ b/services/core/java/com/android/server/wm/DisplayContent.java
@@ -1520,10 +1520,6 @@ class DisplayContent extends WindowContainer<DisplayContent.DisplayChildWindowCo
             // has it own policy for bounds, the activity bounds based on parent is unknown.
             return false;
         }
-        if (mPinnedStackControllerLocked.isPipActiveOrWindowingModeChanging()) {
-            // Use normal rotation animation because seamless PiP rotation is not supported yet.
-            return false;
-        }
 
         setFixedRotationLaunchingApp(r, rotation);
         return true;


### PR DESCRIPTION
While seamless PIP rotation is not yet supported losing seamless rotation (and having to deal with the pause+rotation animation) is arguably an worse UX than the PIP window suddenly changing orientation (as that already tends to happen when going from landscape to the homescreen)